### PR TITLE
Removendo a múltiplas chamadas de função em loyalty_lib

### DIFF
--- a/data/libs/loyalty_lib.lua
+++ b/data/libs/loyalty_lib.lua
@@ -33,27 +33,33 @@ function Player.initializeLoyaltySystem(self)
 		return true
 	end
 
+    local playerLoyaltyPoints = self:getLoyaltyPoints()
+
 	-- Title
 	local title = ""
 	for _, titleTable in ipairs(loyaltySystem.titles) do
-		if (self:getLoyaltyPoints() > titleTable.points) then
+		if playerLoyaltyPoints >= titleTable.points then
 			title = titleTable.name
 		end
 	end
-	self:setLoyaltyTitle(title)
+
+    if title ~= "" then
+      self:setLoyaltyTitle(title)
+    end
 
 	-- Bonus
-	local bonusPercentage = 0
+	local playerBonusPercentage = 0
 	for _, bonusTable in ipairs(loyaltySystem.bonus) do
-		if self:getLoyaltyPoints() >= bonusTable.minPoints then
-			bonusPercentage = bonusTable.percentage
+		if playerLoyaltyPoints >= bonusTable.minPoints then
+			playerBonusPercentage = bonusTable.percentage
 		end
 	end
 
-	self:setLoyaltyBonus(bonusPercentage * configManager.getFloat(configKeys.LOYALTY_BONUS_PERCENTAGE_MULTIPLIER))
+    playerBonusPercentage = playerBonusPercentage * configManager.getFloat(configKeys.LOYALTY_BONUS_PERCENTAGE_MULTIPLIER)
+	self:setLoyaltyBonus(playerBonusPercentage)
 
 	if self:getLoyaltyBonus() ~= 0 then
-		self:sendTextMessage(MESSAGE_STATUS, string.formatNamed(loyaltySystem.messageTemplate, { bonusPercentage = self:getLoyaltyBonus(), loyaltyPoints = self:getLoyaltyPoints()}))
+		self:sendTextMessage(MESSAGE_STATUS, string.formatNamed(loyaltySystem.messageTemplate, { bonusPercentage = playerBonusPercentage, loyaltyPoints = playerLoyaltyPoints}))
 	end
 
 	return true

--- a/data/libs/loyalty_lib.lua
+++ b/data/libs/loyalty_lib.lua
@@ -37,7 +37,7 @@ function Player.initializeLoyaltySystem(self)
 
 	-- Title
 	local title = ""
-    for _, titleTable in ipairs(loyaltySystem.titles) do
+	for _, titleTable in ipairs(loyaltySystem.titles) do
 		if playerLoyaltyPoints >= titleTable.points then
 			title = titleTable.name
 		end

--- a/data/libs/loyalty_lib.lua
+++ b/data/libs/loyalty_lib.lua
@@ -33,19 +33,19 @@ function Player.initializeLoyaltySystem(self)
 		return true
 	end
 
-    local playerLoyaltyPoints = self:getLoyaltyPoints()
+	local playerLoyaltyPoints = self:getLoyaltyPoints()
 
 	-- Title
 	local title = ""
-	for _, titleTable in ipairs(loyaltySystem.titles) do
+    for _, titleTable in ipairs(loyaltySystem.titles) do
 		if playerLoyaltyPoints >= titleTable.points then
 			title = titleTable.name
 		end
 	end
 
-    if title ~= "" then
-      self:setLoyaltyTitle(title)
-    end
+	if title ~= "" then
+		self:setLoyaltyTitle(title)
+	end
 
 	-- Bonus
 	local playerBonusPercentage = 0
@@ -55,7 +55,7 @@ function Player.initializeLoyaltySystem(self)
 		end
 	end
 
-    playerBonusPercentage = playerBonusPercentage * configManager.getFloat(configKeys.LOYALTY_BONUS_PERCENTAGE_MULTIPLIER)
+	playerBonusPercentage = playerBonusPercentage * configManager.getFloat(configKeys.LOYALTY_BONUS_PERCENTAGE_MULTIPLIER)
 	self:setLoyaltyBonus(playerBonusPercentage)
 
 	if self:getLoyaltyBonus() ~= 0 then


### PR DESCRIPTION
Mesmo que seja imperceptível, isso pode ser melhor escrito desta maneira.

Creio que os títulos são alcançados nos devidos pontos e não acima deles. 

Não tenho certeza se o "title" e o "bonus" precisam ser trocados mesmo que seja "" e 0, respectivamente. 